### PR TITLE
fix build for vs2026

### DIFF
--- a/cxx/quickjs/libregexp.c
+++ b/cxx/quickjs/libregexp.c
@@ -27,6 +27,10 @@
 #include <inttypes.h>
 #include <string.h>
 #include <assert.h>
+#ifdef _MSC_VER
+#include <malloc.h>
+#define alloca _alloca
+#endif
 
 #include "cutils.h"
 #include "libregexp.h"

--- a/cxx/quickjs/quickjs.c
+++ b/cxx/quickjs/quickjs.c
@@ -40,8 +40,26 @@
 #endif
 
 #ifdef _MSC_VER
+#include <malloc.h>
+#define alloca _alloca
+#pragma function (fabs)
 #pragma function (ceil)
 #pragma function (floor)
+#pragma function (sqrt)
+#pragma function (acos)
+#pragma function (asin)
+#pragma function (atan)
+#pragma function (atan2)
+#pragma function (cos)
+#pragma function (exp)
+#pragma function (log)
+#pragma function (sin)
+#pragma function (tan)
+#pragma function (cosh)
+#pragma function (sinh)
+#pragma function (tanh)
+#pragma function (log2)
+#pragma function (log10)
 
 #include <WinSock2.h>
 


### PR DESCRIPTION
Somehow the source code failed to be built in vs2026 (msvc 14.51.36231)

<details>

<summary>log</summary>

C:\Users\CWK-Test\qjcb>cmake --build .\build\windows
[2/7] Building C object CMakeFiles\quickjs.dir\C_\Users\CWK-Test\qjcb\cxx\quickjs\cutils.c.obj
C:\Users\CWK-Test\qjcb\cxx\quickjs\cutils.c(53): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\cutils.c(238): warning C4244: 'return': conversion from '__int64' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\cutils.c(300): warning C4018: '<': signed/unsigned mismatch
[3/7] Building C object CMakeFiles\quickjs.dir\C_\Users\CWK-Test\qjcb\cxx\quickjs\libunicode.c.obj
C:\Users\CWK-Test\qjcb\cxx\quickjs\libunicode.c(676): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\libunicode.c(887): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
[4/7] Building C object CMakeFiles\quickjs.dir\C_\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c.obj
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(404): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(413): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(468): warning C4244: 'return': conversion from 'uint64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1237): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1275): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1299): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1313): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1339): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1448): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1458): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1478): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1571): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1580): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1595): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1602): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1668): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1681): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1745): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1751): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1766): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1885): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1893): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(1907): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(2076): warning C4267: '=': conversion from 'size_t' to 'uint8_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(2330): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\libregexp.c(2531): warning C4244: '=': conversion from 'intptr_t' to 'int', possible loss of data
[5/7] Building C object CMakeFiles\quickjs.dir\C_\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c.obj
FAILED: [code=2] CMakeFiles/quickjs.dir/C_/Users/CWK-Test/qjcb/cxx/quickjs/quickjs.c.obj
C:\PROGRA~1\MICROS~3\18\COMMUN~1\VC\Tools\MSVC\1451~1.362\bin\Hostx64\x64\cl.exe  /nologo   /DWIN32 /D_WINDOWS /W3 /MD /O2 /Ob2 /DNDEBUG -DCONFIG_VERSION=\"2021-03-27\" -DDUMP_LEAKS /showIncludes /FoCMakeFiles\quickjs.dir\C_\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c.obj /FdCMakeFiles\quickjs.dir\quickjs.pdb /FS -c C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(1445): warning C4267: '+=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(1621): warning C4047: 'return': 'uintptr_t' differs in levels of indirection from 'void *'
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(1899): warning C4244: 'return': conversion from 'uintptr_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(2485): warning C4244: '=': conversion from 'uint64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(2536): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(2601): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(2642): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3091): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3097): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3423): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3438): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3442): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3483): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3523): warning C4244: 'initializing': conversion from 'uint16_t' to 'uint8_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3551): warning C4244: '=': conversion from 'uint16_t' to 'uint8_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3625): warning C4267: '+=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3656): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3733): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3786): warning C4244: '=': conversion from 'const uint16_t' to 'uint8_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3796): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3918): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3920): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3922): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3928): warning C4244: 'function': conversion from '__int64' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3974): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(3975): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(4096): warning C4244: '=': conversion from '__int64' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(4317): warning C4244: 'function': conversion from 'uintptr_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(4438): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(4462): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(4524): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(4589): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(5290): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(5302): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(6046): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(6078): warning C4244: '+=': conversion from 'double' to 'int64_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(6079): warning C4244: '+=': conversion from 'double' to 'int64_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(6211): warning C4244: '=': conversion from 'double' to 'int64_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(6212): warning C4244: '=': conversion from 'double' to 'int64_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(6214): warning C4244: '=': conversion from 'double' to 'int64_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(6221): warning C4244: '+=': conversion from 'double' to 'int64_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(6249): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(6252): warning C4267: 'initializing': conversion from 'size_t' to 'unsigned int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(6398): warning C4146: unary minus operator applied to unsigned type, result still unsigned
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(6414): warning C4244: 'return': conversion from '__int64' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(6431): warning C4146: unary minus operator applied to unsigned type, result still unsigned
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(6473): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(6558): warning C4244: 'function': conversion from '__int64' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(7555): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(7645): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(7959): warning C4244: 'function': conversion from 'int64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(7961): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(7989): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(8070): warning C4018: '>': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(8113): warning C4244: '=': conversion from '__int64' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(8136): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(8219): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(8236): warning C4018: '<=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(8303): warning C4267: '+=': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(8781): warning C4244: '=': conversion from 'double' to 'float', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(8827): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(9017): warning C4244: '=': conversion from '__int64' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(9732): warning C4244: 'function': conversion from 'int64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(9846): warning C4047: 'return': 'JSClassID' differs in levels of indirection from 'void *'
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(10056): warning C4244: 'return': conversion from '__int64' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(10108): warning C4244: '=': conversion from 'uint64_t' to 'double', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(10345): warning C4244: '=': conversion from '__int64' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(11506): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(11511): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(11521): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(11583): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(11710): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(11826): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(11858): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(15203): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(15221): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(15281): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(17417): warning C4244: 'function': conversion from '__int64' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(17427): warning C4244: 'function': conversion from '__int64' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(17440): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(17980): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(18008): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(18045): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(18082): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(21618): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(21669): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(21670): warning C4267: 'return': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(21855): warning C4267: '+=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(23053): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(23339): warning C4244: '=': conversion from '__int64' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(23961): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(23975): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(26144): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(26205): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(26280): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(26274): warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(26642): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(26653): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(26672): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(26781): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(26666): warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(27324): warning C4244: '=': conversion from '__int64' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(27360): warning C4996: 'strcat': This function or variable may be unsafe. Consider using strcat_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(27361): warning C4996: 'strcat': This function or variable may be unsafe. Consider using strcat_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(28876): warning C4267: 'function': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(30058): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(30753): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(30847): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31045): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31191): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31419): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31517): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31549): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31554): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31585): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31640): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31650): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31660): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31669): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31692): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31695): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31717): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31722): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31727): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31730): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31753): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31761): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31808): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31825): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31837): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31850): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31870): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31901): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31915): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31923): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31942): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31970): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31993): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32004): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32025): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32039): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32046): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32057): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32072): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32077): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32103): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32110): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32119): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32147): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32156): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32172): warning C4267: 'function': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32231): warning C4018: '>': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(31674): warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32297): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32340): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32621): warning C4267: '+=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32629): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(32687): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(33348): warning C4244: '=': conversion from '__int64' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(33373): warning C4244: '=': conversion from '__int64' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(33847): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(33867): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(33869): warning C4018: '<=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(34045): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(34049): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(34202): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(34538): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(34769): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(35043): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(35090): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(35895): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(35937): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(35956): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(35971): warning C4267: '+=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(36026): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(38140): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(38173): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(38185): warning C4244: 'function': conversion from 'int64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(38444): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(38500): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(38523): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(38717): warning C4244: 'function': conversion from 'int64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(38931): warning C4244: 'function': conversion from 'int64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(39035): warning C4244: 'function': conversion from 'int64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(39048): warning C4244: '=': conversion from 'int64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(39049): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(40395): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(40423): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(40451): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(40565): warning C4244: '=': conversion from 'double' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(40788): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(40804): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(40811): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(40817): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(40914): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(41030): warning C4244: 'function': conversion from 'int64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(41033): warning C4244: 'function': conversion from 'int64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(41033): warning C4244: 'function': conversion from 'int64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(41042): warning C4244: 'function': conversion from 'int64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(41042): warning C4244: 'function': conversion from 'int64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(41238): warning C4244: '=': conversion from 'int64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(41340): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(41386): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(41650): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(41964): error C2099: initializer is not a constant
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(42616): warning C4244: 'function': conversion from 'int64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(42636): warning C4244: 'function': conversion from '__int64' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(42657): warning C4244: '=': conversion from '__int64' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(42658): warning C4244: '=': conversion from '__int64' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(42681): warning C4244: 'function': conversion from '__int64' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(42744): warning C4244: 'function': conversion from 'int64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(42758): warning C4244: '=': conversion from '__int64' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(42759): warning C4244: '=': conversion from '__int64' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(43119): warning C4267: '+=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(43255): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(43274): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(43297): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(43308): warning C4244: 'function': conversion from 'int64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(43310): warning C4244: '=': conversion from 'int64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(43462): warning C4244: '=': conversion from 'int64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(43469): warning C4244: '=': conversion from 'int64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(43479): warning C4244: '=': conversion from 'int64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(45672): warning C4244: '=': conversion from 'uintptr_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(45725): warning C4267: '+=': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(47639): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(47641): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(47662): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(47774): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(47784): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48001): warning C4244: '=': conversion from 'double' to 'int64_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48028): warning C4244: '=': conversion from 'int64_t' to 'double', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48029): warning C4244: '=': conversion from 'int64_t' to 'double', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48030): warning C4244: '=': conversion from 'int64_t' to 'double', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48031): warning C4244: '=': conversion from 'int64_t' to 'double', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48032): warning C4244: '=': conversion from 'int64_t' to 'double', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48033): warning C4244: '=': conversion from 'int64_t' to 'double', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48034): warning C4244: '=': conversion from 'int64_t' to 'double', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48035): warning C4244: '=': conversion from 'int64_t' to 'double', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48036): warning C4244: '=': conversion from 'int64_t' to 'double', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48055): warning C4244: '=': conversion from 'double' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48059): warning C4244: '=': conversion from 'int64_t' to 'double', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48064): warning C4244: '+=': conversion from 'int64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48072): warning C4244: 'function': conversion from 'double' to 'int64_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48160): warning C4244: '=': conversion from 'double' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48161): warning C4244: '=': conversion from 'double' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48162): warning C4244: '=': conversion from 'double' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48163): warning C4244: '=': conversion from 'double' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48164): warning C4244: '=': conversion from 'double' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48165): warning C4244: '=': conversion from 'double' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48166): warning C4244: '=': conversion from 'double' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48167): warning C4244: '=': conversion from 'double' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48168): warning C4244: '=': conversion from 'double' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48265): warning C4244: '=': conversion from 'int64_t' to 'double', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48353): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48358): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48367): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48370): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48389): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48409): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48426): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48429): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48451): warning C4018: '<=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48498): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48505): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48540): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48575): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48601): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48615): warning C4018: '<': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(48631): warning C4244: '=': conversion from 'int64_t' to 'double', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(51177): warning C4244: '=': conversion from 'uint64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(51182): warning C4244: 'function': conversion from 'uint64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(51188): warning C4244: 'function': conversion from 'uint64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(51616): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(51701): warning C4244: 'function': conversion from 'int64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(51898): warning C4244: 'function': conversion from 'int64_t' to 'int32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52017): warning C4244: '=': conversion from 'double' to 'float', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52045): warning C4244: 'function': conversion from 'uint64_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52050): warning C4244: '=': conversion from 'uint64_t' to 'uint16_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52055): warning C4244: '=': conversion from 'uint64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52150): warning C4244: '=': conversion from 'double' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52156): warning C4244: '=': conversion from 'double' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52189): warning C4244: '=': conversion from 'int64_t' to 'double', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52193): warning C4244: '=': conversion from 'double' to 'int64_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52229): warning C4244: '=': conversion from 'int64_t' to 'uint16_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52233): warning C4244: '=': conversion from '__int64' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52254): warning C4244: '=': conversion from 'int64_t' to 'uint16_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52273): warning C4244: '=': conversion from 'int64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52529): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52530): warning C4018: '>=': signed/unsigned mismatch
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52827): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52838): warning C4267: '=': conversion from 'size_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52840): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52961): warning C4244: '=': conversion from 'uint64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52962): warning C4244: '=': conversion from 'uint64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(52965): warning C4244: '=': conversion from 'uint64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(53250): warning C4244: '=': conversion from 'uint64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(53257): warning C4244: '=': conversion from 'uint64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(53277): warning C4244: '=': conversion from 'uint64_t' to 'uint32_t', possible loss of data
C:\Users\CWK-Test\qjcb\cxx\quickjs\quickjs.c(53428): warning C4244: '=': conversion from 'double' to 'float', possible loss of data
ninja: build stopped: subcommand failed.
</details>

After apply these changes the build succeeded 

```

C:\Users\CWK-Test\quickjs-c-bridge\build\windows>dumpbin /headers quickjs_c_bridge.dll | findstr machine
            8664 machine (x64)

```
even for windows arm64 (cross compiling from x64)

```
C:\Users\CWK-Test\quickjs-c-bridge\build\windows-arm64>dumpbin /headers quickjs_c_bridge.dll | findstr machine
            AA64 machine (ARM64)

```


